### PR TITLE
Fixes errors when downloading images with Gatsby v4

### DIFF
--- a/src/nodes/images.js
+++ b/src/nodes/images.js
@@ -62,7 +62,7 @@ async function createImageNodeFromFile(context, file) {
 
 export async function downloadAndCacheImage(
     { url, nodeId },
-    { createNode, createNodeId, touchNode, store, cache, getCache, reporter }
+    { createNode, createNodeId, touchNode, store, cache, getCache, reporter, getNode }
 ) {
     let fileNodeID;
 
@@ -75,7 +75,7 @@ export async function downloadAndCacheImage(
 
     if (cachedImageNode) {
         fileNodeID = cachedImageNode.fileNodeID;
-        touchNode({ nodeId: fileNodeID });
+        touchNode(getNode(fileNodeID));
         return fileNodeID;
     }
 


### PR DESCRIPTION
The arguments passed to the `touchNode` action have changed in Gatsby v4. This causes the plugin to produce an error.

This PR should fix the issue and close #26 ... but is probably going to produce errors with Gatsby v3 and below. I have no experience in developing Gatsby plugins, so I have no idea if there is a way to conditionally switch for v4 and v3.

Gatsby v4 migration article for `toucNode`: https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v3-to-v4/#change-arguments-passed-to-touchnode-action




